### PR TITLE
docs: rewrite README for clarity and accuracy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2024 Intempt
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,250 +1,198 @@
-# Intempt - Node SDK
+# Intempt Node.js SDK
 
-[Intempt](https://intempt.com/?utm_campaign=sdk&utm_medium=docs&utm_source=github) is a GrowthOS built for the needs of SAAS and eCommerce companies focusing to grow their customer LTV.
-This is a library to facilitate tracking of anonymous and logged-in user traffic on your Node.js server.
+Server-side Node.js client for the [Intempt](https://intempt.com) analytics platform.
 
-## Contents:
+## Installation
 
-* [1](https://github.com/intempt/sdk-node#installation-and-initialization) - Installation and Initialization 
-* [2](https://github.com/intempt/sdk-node#identifying-visitors) - How to identify a user
-* [3](https://github.com/intempt/sdk-node#recording-events) - Recording Events
-* [4](https://github.com/intempt/sdk-node#create-custom-collections) - Create Custom Collections
-* [5](https://github.com/intempt/sdk-node#batching) - Batching
-* [6](https://github.com/intempt/sdk-node#get-apis) - Get APIs
-
-## Installation and Initialization
-
-Install our SDK which is an npm package by running 
-```Javascript
-    npm install @intempt/sdk
+```bash
+npm install intempt
 ```
 
-To update to the latest version, run
-
-```Javascript
-    npm install intempt-nodejs-source@latest
-```
-
-[Login](https://app.intempt.com) to Intempt and obtain your snippet from the [sources](https://app.intempt.com/sources) page:
-
-### Import
-
-How to import the whole sdk:
-
-```javascript
-    const IntemptSDK = require('@intempt/sdk');
-```
-
-Or
+## Quick Start
 
 ```typescript
-    import * as IntemptSDK from '@intempt/sdk'
+import { SDK as IntemptSDK } from 'intempt';
+
+const intempt = new IntemptSDK('my-org', 'my-project', 'api-key', 'source-id');
+
+// Track a custom event
+await intempt.track('prof_123', 'purchase', { amount: 99.99, currency: 'USD' });
+
+// Identify a user
+await intempt.identify('prof_123', 'john@example.com', null, { name: 'John', plan: 'pro' });
 ```
 
-### Modules
-
-The sdk composed of separated modules / API-s. Some of them are:
-
-1. `CDPMetadata`: the Client Data Platform, where the client specific domain.
-2. `Metric`: 
-3. `PushSource`:
-
-And there are generic generic components like `Configuration`, `ResponseError` or helpers like `EventRecorder` and `EventBatcher`.
-
-### Configuration and Authorization
-
-In order to use or SDK some configuration is necessery, like authorization. The SDK accepts a wide varioty of configuration parameters.
+## Constructor
 
 ```typescript
-interface ConfigurationParameters {
-    basePath?: string; // override base path
-    fetchApi?: FetchAPI; // override for fetch implementation
-    middleware?: Middleware[]; // middleware to apply before/after fetch requests
-    queryParamsStringify?: (params: HTTPQuery) => string; // stringify function for query strings
-    username?: string; // parameter for basic security
-    password?: string; // parameter for basic security
-    apiKey?: string | ((name: string) => string); // parameter for apiKey security
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
-    headers?: HTTPHeaders; //header params we want to use on every request
-    credentials?: RequestCredentials; //value for the credentials param we want to use on each request
-}
+new IntemptSDK(orgName, projectName, apiKey, sourceId, time?, maxSize?)
 ```
 
+| Parameter     | Type     | Required | Description                                      |
+|---------------|----------|----------|--------------------------------------------------|
+| `orgName`     | `string` | Yes      | Your Intempt organization name                   |
+| `projectName` | `string` | Yes      | Your Intempt project name                        |
+| `apiKey`      | `string` | Yes      | API key from your Intempt source                 |
+| `sourceId`    | `string` | Yes      | Source identifier                                |
+| `time`        | `number` | No       | Flush interval in milliseconds                   |
+| `maxSize`     | `number` | No       | Maximum events to buffer before flushing         |
 
-First, Authorization. Our library provide two ways:
+## Methods
 
-A Simple bearer token (jwt) from login. This method higly dependent the `exp` (expiration), which can be from couple of minutes to days. This is not fit for a long running api. 
+### Event Tracking
+
+#### `track(profileId, eventTitle, data)`
+
+Track a custom event.
 
 ```typescript
-const configuration = new IntemptSDK.Configuration({
-    accessToken: 'eyJhbG....'
-});
+await intempt.track('prof_123', 'purchase', { amount: 99.99, currency: 'USD' });
 ```
 
-Every Source comes with a key.
+#### `identify(profileId, userId, eventTitle?, userAttributes?)`
 
-```
-d9371778-b7ab-4d1c-8929-d3ee58e216d3.081ad6c9-dee9-4e64-9384-4cf0ca41c079
-```
+Identify a user across sources.
 
 ```typescript
-const configuration = new IntemptSDK.Configuration({
-    username:'d9371778-b7ab-4d1c-8929-d3ee58e216d3',
-    password:'081ad6c9-dee9-4e64-9384-4cf0ca41c079'
-})
+await intempt.identify('prof_123', 'john@example.com', null, { name: 'John', plan: 'pro' });
 ```
 
-### An API call
+#### `group(profileId, accountId, eventTitle?, accountAttributes?)`
 
-With the set up configuration, our api is avaliable. This example show how to list the sources.
+Associate a profile with an account.
 
 ```typescript
-const sourcesApi = new IntemptSDK.CDPMetadata.SourcesApi(configuration);
-
-await sourcesApi.fetchSources({orgName: orgName, projectName: projectName});
+await intempt.group('prof_123', 'acme-corp', null, { industry: 'SaaS', plan: 'enterprise' });
 ```
 
-About ```
+#### `record(profileId, eventTitle, userId?, accountId?, data?, userAttributes?, accountAttributes?)`
 
-`flushAt`: This has a value of number. This has a default value of `10`. This determines how many items can be stored in memory at a time. For example, if you have `flushAt` set at `1`, this means we can only have one event at a time in our batch memory. 
-
-`flushInterval`: This has a value of number. This has a default value of `10000ms`. This determines how long our memory should hold data before `flushing` to Intempt Servers.. For example, if you have `flushInterval` set at `10000ms`, this means we can only store events for as long as `10 seconds` in our batch memory. 
-
-# Identifying Users
-
-Our SDK provides an exported function to automatically track users. To track a user, all you have to do is to call the function below
-
-```javascript
-	Intempt.profile({profileId: profileId, user_identifier: user_identifier, account_identifier: account_identifier})
-```
-
-`profileId` : This is a profile Identifier which is used to identify users. ```Note```: In your server, it is advisable to use the Id of your users as profileId. That way, it is always unique and you don't need to have a randomizer or generator.
-
-`user_identifier` : User identifier helps to identify users across all sources in your organization. This could be the user's email and so on. Eg. `example@example.com`
-
-
-# Recording Events
-
-Our server-side API allows creation of any event type you might desire to be tracked for your page or application.
-
-Custom collections allow you to bring custom data into your organization.
-
-# Create Custom Collections
-After creating a NodeJS source, switch tabs to the schema and you should see a `profile` and `consents` collections already created. To start tracking custom events for our organization, after creating a [source](https://app.intempt.com/sources) you intend to use on your server, navigate to schema then use the schema Builder to create a collection with your personalized fields. Make sure to add a profileId field and set a profile identifier as one of its properties. [See intempt docs for keys and identifiers](https://dev.intempt.com/#keys-and-identifiers) to find out why.
-
-Set up other custom field properties that match the data you plan to track.
-
-Our SDK by default has a few exported functions for certain event tracking such as `profile`, `trackConsents` . You can log a custom event by calling Intempt's recordEvent function, passing in a set of key-value pairs.
-
-
-```javascript
-    Intempt.recordEvent('COLLECTION_NAME', event);
-```
-
-The COLLECTION_NAME refers to an event type. For example, if you wanted to track every time your server received a purchase request, you might call collection "purchase". Then, when a purchase happens, you call track and pass in the purchase details.
-
-### Example
-
-```javascript
-	Intempt.recordEvent("purchase", {
-		 "items": [{"item name": "item 1","price": 20}, {"item name": "item 2","price": 15}],
-		 "totalprice": 35,
-		 "ispaid": true,
-		 "timestamp": new Date().getTime(),
-		 "fixed.name": "John Smith",
-		 "fixed.age": 28,
-		 "intempt.visit.trackcharge": 35
-	})
-```
-
-In the example above, we have a custom collection with name of `purchase`, then we have an object of key-value pairs. The Object passed into represent the fields we created while creating the collection. 
-
-`NB`: Data type sent should match data type set when creating the collection. For instance, We are sending a field `timestamp` which has a data type of `number`, Sending data with a type of `string` instead of `number` will make this custom collection not get tracked
-
-There are other examples in the `samples` directory.
-
-# Tracking Consents
-
-Save user consents and apply them to data flow. Make sure you have created consents purposes in your organization's settings
-
-
-### Supported Regulation Types - GDPR & CCPA;
-
-Consents are tracked using Intempt's exported function ;
-
-```javascript
-	Intempt.trackConsents(consents)
-```
-
-`Intempt.trackConsents()` expects consents as an array of Objects inorder to be tracked successfully. 
-Example: 
+Send a fully specified event with all optional fields.
 
 ```typescript
-    er.trackConsents(
-      "bob",
-      [
-        {
-          regulation: 'GDPR',
-          purpose: 'advertising',
-          consented: true
-        }, {
-          regulation: 'CCPA',
-          purpose: 'advertising',
-          consented: true
-        }
-      ]
-    );
+await intempt.record('prof_123', 'signup', 'john@example.com', 'acme-corp', { source: 'landing-page' });
 ```
 
-Consents can contain as much as possible depending on your use case.
+#### `alias(profileId, userId, anotherUserId)`
 
-# Batching
-
-Our libraries are built to support high-performance environments. That means it is safe to use our Node library on a web server that’s serving hundreds of requests per second.
-
-Every method you call does not result in an HTTP request, but is queued in memory instead. Messages are then flushed in batch in the background, which allows to perform much faster operations.
-
+Link two user identifiers to the same profile.
 
 ```typescript
-const eventRecorder = IntemptSDK.EventRecorder.WithEventBatcher(
-    orgName,
-    projectName,
-    sourceId,
-    new IntemptSDK.PushSource.SourcesApi(configuration),
-    { maximum:100, interval: 10 });
+await intempt.alias('prof_123', 'john@example.com', 'john.doe@newdomain.com');
 ```
 
-# Get APIs
-Below is a detailed list of functions our SDK makes available to be used in your server.
+### Consent Management (GDPR/CCPA)
 
+#### `consent(profileId, action, category, expirationTime?, email?, message?)`
 
-# Optimization Choose
-
-Select experiments variants and personalization experiences using NodeJS SDK library.
-
-1. Create optimization http client object for choosing
+Record consent for a specific category.
 
 ```typescript
-const optimizationClient = new IntemptSdk.OptimizationClient(configuration);
+await intempt.consent('prof_123', 'accept', 'advertising', '2025-12-31');
 ```
 
-2. Build request parameters (sessionId - optional parameter, userIdentifier - value of user identifier, email usually)
+#### `consents(profileId, action, expirationTime?, email?, message?)`
+
+Record a blanket consent decision (accept or reject all).
 
 ```typescript
-  const requestParameters = {
-    identification: {
-        userId: "user-identifier-value"
-    },
-    sessionId: "current-session-id",
-    url: "page-url",
-    device: "all"
-};
+await intempt.consents('prof_123', 'accept');
 ```
 
-3. Call choose variant request
+### Product Events
+
+#### `productAdd(profileId, productId, quantity)`
+
+Track a product added to cart.
 
 ```typescript
-  const rows = optimizationClient.chooseRows("organization-name", "project-name", requestParameters)
+await intempt.productAdd('prof_123', 'sku-001', 2);
 ```
 
+#### `productView(profileId, productId)`
 
+Track a product page view.
+
+```typescript
+await intempt.productView('prof_123', 'sku-001');
+```
+
+#### `productOrdered(profileId, products)`
+
+Track a completed order.
+
+```typescript
+await intempt.productOrdered('prof_123', [
+  { productId: 'sku-001', quantity: 2 },
+  { productId: 'sku-002', quantity: 1 },
+]);
+```
+
+### Recommendations
+
+#### `recommendation(profileId, id, quantity, fields, productId?)`
+
+Fetch product recommendations.
+
+```typescript
+const recs = await intempt.recommendation('prof_123', 'rec-model-1', 5, ['name', 'price']);
+```
+
+### Experiments and Personalizations
+
+#### `chooseExperimentsByGroups(profileId, groups?)`
+
+Select experiment variants by group.
+
+```typescript
+const variants = await intempt.chooseExperimentsByGroups('prof_123', ['pricing-test']);
+```
+
+#### `chooseExperimentsByNames(profileId, names?)`
+
+Select experiment variants by name.
+
+```typescript
+const variants = await intempt.chooseExperimentsByNames('prof_123', ['header-color-test']);
+```
+
+#### `choosePersonalizationsByGroups(profileId, groups?)`
+
+Select personalizations by group.
+
+#### `choosePersonalizationsByNames(profileId, names?)`
+
+Select personalizations by name.
+
+### Privacy Controls
+
+#### `optIn()`
+
+Resume event tracking after a previous opt-out.
+
+#### `optOut()`
+
+Stop all event tracking. Events are silently discarded until `optIn()` is called.
+
+## Batching
+
+Events are queued in memory and flushed to Intempt in batches. Flush behavior depends on the constructor parameters:
+
+- **No `time` or `maxSize`**: events are sent immediately (no batching).
+- **`time`**: events flush after the specified interval (milliseconds).
+- **`maxSize`**: events flush when the buffer reaches the specified size.
+- **Both**: events flush on whichever condition is met first.
+
+```typescript
+// Flush every 10 seconds or every 100 events, whichever comes first
+const intempt = new IntemptSDK('my-org', 'my-project', 'api-key', 'source-id', 10000, 100);
+```
+
+## Requirements
+
+- Node.js 14+
+- TypeScript support included (ships with type declarations)
+
+## License
+
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/intempt/sdk-node.git"
+    "url": "git+https://github.com/intempt/intempt-node.git"
   },
   "devDependencies": {
     "@jest/globals": "^29.4.3",


### PR DESCRIPTION
## Summary

- Rewrote README from scratch to match the actual SDK API surface (all methods from `src/SDK.ts` documented with signatures and examples)
- Replaced Apache 2.0 LICENSE with MIT
- Updated `package.json` repository URL to `intempt/intempt-node`
- Updated git remote origin to `https://github.com/intempt/intempt-node.git`

## Changes

- **README.md**: Replaced verbose, outdated content (wrong package names like `@intempt/sdk`, references to old `CDPMetadata`/`PushSource` modules, typos, broken TOC links) with a clean, concise README covering: installation, quick start, constructor parameters, all public methods with signatures and code examples, batching behavior, and requirements.
- **LICENSE**: Changed from Apache 2.0 to MIT.
- **package.json**: Fixed `repository.url` from `sdk-node` to `intempt-node`.